### PR TITLE
Add persistent mesh mode with background service

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
     
     <!-- Battery optimization permission -->
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
+    <!-- Boot completed permission for auto-start -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     
     <!-- Hardware features -->
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true" />
@@ -50,5 +52,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <!-- Receiver to handle device boot (starts persistent mesh if enabled) -->
+        <receiver android:name=".BootReceiver"
+                  android:enabled="true"
+                  android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+        <!-- Foreground service to keep mesh network active in background -->
+        <service android:name=".PersistentMeshService"
+                 android:exported="false"
+                 android:stopWithTask="false"
+                 android:foregroundServiceType="location|connectedDevice" />
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/BitchatApplication.kt
+++ b/app/src/main/java/com/bitchat/android/BitchatApplication.kt
@@ -1,6 +1,8 @@
 package com.bitchat.android
 
 import android.app.Application
+import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.model.BitchatMessage
 
 /**
  * Main application class for bitchat Android
@@ -12,5 +14,10 @@ class BitchatApplication : Application() {
         
         // Initialize any global services or configurations
         // For now, keep it simple
+    }
+
+    companion object {
+        @Volatile var meshServiceInstance: BluetoothMeshService? = null
+        @Volatile var offlineMessages: MutableMap<String, MutableList<BitchatMessage>> = mutableMapOf()
     }
 }

--- a/app/src/main/java/com/bitchat/android/BootReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootReceiver.kt
@@ -1,0 +1,30 @@
+package com.bitchat.android
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (Intent.ACTION_BOOT_COMPLETED == intent.action) {
+            try {
+                val prefs = context.getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+                val persistent = prefs.getBoolean("persistent_mode", false)
+                val startOnBoot = prefs.getBoolean("start_on_boot", false)
+                if (persistent && startOnBoot) {
+                    Log.d("BootReceiver", "Starting PersistentMeshService on boot")
+                    val serviceIntent = Intent(context, PersistentMeshService::class.java)
+                    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                        context.startForegroundService(serviceIntent)
+                    } else {
+                        context.startService(serviceIntent)
+                    }
+                }
+            } catch (e: Exception) {
+                Log.e("BootReceiver", "Failed to start service on boot: ${e.message}")
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
@@ -1,0 +1,132 @@
+package com.bitchat.android
+
+import android.app.Service
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.Context
+import android.os.Build
+import android.os.IBinder
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import com.bitchat.android.mesh.BluetoothMeshDelegate
+import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.R
+
+class PersistentMeshService : Service(), BluetoothMeshDelegate {
+    companion object {
+        const val CHANNEL_ID = "bitchat_foreground"
+        private const val NOTIF_ID = 1
+        @Volatile var instance: PersistentMeshService? = null
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this  // track current instance for delegate hand-off
+        createNotificationChannel()
+        Log.d("PersistentMeshService", "Service created")
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Start or attach to the mesh network
+        val mesh = BitchatApplication.meshServiceInstance
+        if (mesh == null) {
+            // No mesh running yet – start a new one
+            BitchatApplication.meshServiceInstance = BluetoothMeshService(applicationContext)
+            BitchatApplication.meshServiceInstance!!.startServices()
+            // Set this service as delegate to handle callbacks (no UI active)
+            BitchatApplication.meshServiceInstance!!.delegate = this
+            Log.d("PersistentMeshService", "Started new mesh service in background")
+        } else {
+            // Mesh already running (likely UI just toggled persistent on)
+            // Do NOT override delegate here; delegate will be handed off on UI destroy
+            Log.d("PersistentMeshService", "Mesh service already running, continuing in background")
+        }
+
+        // Prepare a persistent notification
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, notificationIntent, PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val notification: Notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentTitle("Mesh Network Active")
+            .setContentText("BitChat mesh is running in the background.")
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .build()
+
+        startForeground(NOTIF_ID, notification)
+        return START_STICKY
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("PersistentMeshService", "Service destroyed")
+        instance = null
+        // If the service is being stopped (e.g., user disabled persistent mode),
+        // remove the foreground notification. Mesh stopping is handled by Activity if needed.
+        stopForeground(true)
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    /** BluetoothMeshDelegate implementations for background mode **/
+    override fun didReceiveMessage(message: BitchatMessage) {
+        // Only handle private messages in background. Ignore group messages (ephemeral).
+        if (message.isPrivate) {
+            val senderID = message.senderPeerID ?: return
+            val nickname = message.sender.takeIf { it.isNotEmpty() } ?: senderID
+            val offlineList = BitchatApplication.offlineMessages.getOrPut(senderID) { mutableListOf() }
+            offlineList.add(message)
+            try {
+                val notificationManager = com.bitchat.android.ui.NotificationManager(applicationContext)
+                notificationManager.showPrivateMessageNotification(senderID, nickname, message.content)
+            } catch (e: Exception) {
+                Log.e("PersistentMeshService", "Error showing DM notification: ${e.message}")
+            }
+            Log.d("PersistentMeshService", "Received private message from $nickname (stored for later)")
+        }
+    }
+
+    override fun didUpdatePeerList(peers: List<String>) {
+        Log.d("PersistentMeshService", "Peers updated: ${peers.size} connected")
+    }
+
+    override fun didReceiveChannelLeave(channel: String, fromPeer: String) {
+    }
+
+    override fun didReceiveDeliveryAck(ack: com.bitchat.android.model.DeliveryAck) {
+        Log.d("PersistentMeshService", "Delivery ACK received for message ${ack.originalMessageID}")
+    }
+
+    override fun didReceiveReadReceipt(receipt: com.bitchat.android.model.ReadReceipt) {
+        Log.d("PersistentMeshService", "Read receipt received for message ${receipt.originalMessageID}")
+    }
+
+    override fun getNickname(): String? {
+        val prefs = getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
+        return prefs.getString("nickname", null) ?: "anon"
+    }
+
+    override fun isFavorite(peerID: String): Boolean {
+        return false
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Mesh Background Service",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            channel.description = "Keeps the mesh network active in background"
+            val nm = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
@@ -107,6 +107,11 @@ class PersistentMeshService : Service(), BluetoothMeshDelegate {
         Log.d("PersistentMeshService", "Read receipt received for message ${receipt.originalMessageID}")
     }
 
+    override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? {
+        // Channel messages are ignored in background mode; return null so they remain encrypted
+        return null
+    }
+
     override fun getNickname(): String? {
         val prefs = getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
         return prefs.getString("nickname", null) ?: "anon"

--- a/app/src/main/java/com/bitchat/android/ui/DataManager.kt
+++ b/app/src/main/java/com/bitchat/android/ui/DataManager.kt
@@ -28,6 +28,23 @@ class DataManager(private val context: Context) {
     val favoritePeers: Set<String> get() = _favoritePeers
     val blockedUsers: Set<String> get() = _blockedUsers
     val channelMembers: Map<String, MutableSet<String>> get() = _channelMembers
+
+    // MARK: - Persistent Mode Preferences
+    fun isPersistentModeEnabled(): Boolean {
+        return prefs.getBoolean("persistent_mode", false)
+    }
+
+    fun setPersistentMode(enabled: Boolean) {
+        prefs.edit().putBoolean("persistent_mode", enabled).apply()
+    }
+
+    fun isStartOnBootEnabled(): Boolean {
+        return prefs.getBoolean("start_on_boot", false)
+    }
+
+    fun setStartOnBoot(enabled: Boolean) {
+        prefs.edit().putBoolean("start_on_boot", enabled).apply()
+    }
     
     // MARK: - Nickname Management
     

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -319,6 +319,47 @@ fun PeopleSection(
                 )
             }
         }
+        // Push toggle controls to bottom
+        Spacer(modifier = Modifier.weight(1f))
+        // Persistent Network toggle
+        val persistentEnabled by viewModel.persistentModeEnabled.observeAsState(false)
+        val startBootEnabled by viewModel.startOnBootEnabled.observeAsState(false)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.persistent_network),
+                style = MaterialTheme.typography.bodyMedium,
+                color = colorScheme.onSurface
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Switch(
+                checked = persistentEnabled,
+                onCheckedChange = { viewModel.setPersistentModeEnabled(it) }
+            )
+        }
+        // Start on Boot toggle (enabled only if persistent mode is on)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(id = R.string.start_on_boot),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (persistentEnabled) colorScheme.onSurface else colorScheme.onSurface.copy(alpha = 0.5f)
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Switch(
+                checked = startBootEnabled,
+                onCheckedChange = { viewModel.setStartOnBootEnabled(it) },
+                enabled = persistentEnabled
+            )
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,8 @@
     <string name="show_commands">Show commands</string>
     <string name="back">Back</string>
     <string name="people">People</string>
+    <string name="persistent_network">Persistent Background Mesh</string>
+    <string name="start_on_boot">Start on Boot</string>
     <string name="channels">Channels</string>
     <string name="online_users">Online Users</string>
     <string name="no_one_connected">No one connected</string>


### PR DESCRIPTION
## Summary
- allow mesh to persist in background via foreground service
- add boot receiver and settings toggles for persistence and autostart
- share mesh instance and offline messages through application class

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e8d5bcaa88333b73ef776af71431e