### PR TITLE
Implement stub decryptChannelMessage in persistent service

### DIFF
--- a/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/PersistentMeshService.kt
@@ -107,6 +107,11 @@ class PersistentMeshService : Service(), BluetoothMeshDelegate {
         Log.d("PersistentMeshService", "Read receipt received for message ${receipt.originalMessageID}")
     }
 
+    override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? {
+        // Channel messages are ignored in background mode; return null so they remain encrypted
+        return null
+    }
+
     override fun getNickname(): String? {
         val prefs = getSharedPreferences("bitchat_prefs", Context.MODE_PRIVATE)
         return prefs.getString("nickname", null) ?: "anon"


### PR DESCRIPTION
## Summary
- implement `decryptChannelMessage` stub in `PersistentMeshService` to satisfy `BluetoothMeshDelegate`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e539568c8333be958a9fbd55ce1e