### PR TITLE
Add background mesh persistence with notification

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,10 @@
     
     <!-- Notification permissions -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     
     <!-- Haptic feedback permission -->
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -50,5 +54,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".MeshForegroundService"
+            android:exported="false"
+            android:foregroundServiceType="location" />
+        <receiver
+            android:name=".BootReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/java/com/bitchat/android/BitchatApplication.kt
+++ b/app/src/main/java/com/bitchat/android/BitchatApplication.kt
@@ -1,16 +1,17 @@
 package com.bitchat.android
 
 import android.app.Application
+import com.bitchat.android.mesh.BluetoothMeshService
 
 /**
  * Main application class for bitchat Android
  */
 class BitchatApplication : Application() {
-    
+    val meshService: BluetoothMeshService by lazy { BluetoothMeshService(this) }
+
     override fun onCreate() {
         super.onCreate()
-        
+
         // Initialize any global services or configurations
-        // For now, keep it simple
     }
 }

--- a/app/src/main/java/com/bitchat/android/BootReceiver.kt
+++ b/app/src/main/java/com/bitchat/android/BootReceiver.kt
@@ -1,0 +1,34 @@
+package com.bitchat.android
+
+import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import com.bitchat.android.ui.DataManager
+
+class BootReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        if (intent?.action == Intent.ACTION_BOOT_COMPLETED) {
+            val dm = DataManager(context.applicationContext)
+            if (dm.isPersistentNetworkEnabled() && dm.isStartOnBootEnabled()) {
+                val hasLocation = ContextCompat.checkSelfPermission(
+                    context,
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED ||
+                    ContextCompat.checkSelfPermission(
+                        context,
+                        Manifest.permission.ACCESS_COARSE_LOCATION
+                    ) == PackageManager.PERMISSION_GRANTED
+
+                if (hasLocation) {
+                    val serviceIntent = Intent(context, MeshForegroundService::class.java).apply {
+                        action = MeshForegroundService.ACTION_USE_BACKGROUND_DELEGATE
+                    }
+                    context.startForegroundService(serviceIntent)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/bitchat/android/MeshForegroundService.kt
+++ b/app/src/main/java/com/bitchat/android/MeshForegroundService.kt
@@ -1,0 +1,128 @@
+package com.bitchat.android
+
+import android.Manifest
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.bitchat.android.mesh.BluetoothMeshDelegate
+import com.bitchat.android.mesh.BluetoothMeshService
+import com.bitchat.android.model.BitchatMessage
+import com.bitchat.android.model.DeliveryAck
+import com.bitchat.android.model.ReadReceipt
+import com.bitchat.android.ui.DataManager
+import com.bitchat.android.ui.NotificationManager as PMNotificationManager
+
+class MeshForegroundService : Service() {
+    private lateinit var meshService: BluetoothMeshService
+    private lateinit var dataManager: DataManager
+    private lateinit var notificationManager: PMNotificationManager
+    private val backgroundDelegate = object : BluetoothMeshDelegate {
+        override fun didReceiveMessage(message: BitchatMessage) {
+            if (message.isPrivate) {
+                message.senderPeerID?.let { sender ->
+                    dataManager.savePendingPrivateMessage(message)
+                    notificationManager.showPrivateMessageNotification(sender, message.sender, message.content)
+                }
+            }
+        }
+        override fun didUpdatePeerList(peers: List<String>) {}
+        override fun didReceiveChannelLeave(channel: String, fromPeer: String) {}
+        override fun didReceiveDeliveryAck(ack: DeliveryAck) {}
+        override fun didReceiveReadReceipt(receipt: ReadReceipt) {}
+        override fun decryptChannelMessage(encryptedContent: ByteArray, channel: String): String? = null
+        override fun getNickname(): String? = null
+        override fun isFavorite(peerID: String): Boolean = false
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        val app = application as BitchatApplication
+        meshService = app.meshService
+        dataManager = DataManager(applicationContext)
+        notificationManager = PMNotificationManager(applicationContext)
+        notificationManager.setAppBackgroundState(true)
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        val hasLocation = ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+            ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_COARSE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+
+        if (!hasLocation) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        val notification = createNotification()
+        try {
+            startForeground(NOTIFICATION_ID, notification)
+        } catch (_: SecurityException) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
+
+        when (intent?.action) {
+            ACTION_START -> {
+                if (!meshService.isRunning()) {
+                    meshService.startServices()
+                }
+            }
+            ACTION_USE_BACKGROUND_DELEGATE -> {
+                meshService.delegate = backgroundDelegate
+                if (!meshService.isRunning()) {
+                    meshService.startServices()
+                }
+            }
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        if (meshService.delegate === backgroundDelegate) {
+            meshService.delegate = null
+        }
+    }
+
+    private fun createNotification(): Notification {
+        val channelId = CHANNEL_ID
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(channelId, "Mesh Network", NotificationManager.IMPORTANCE_LOW)
+            val nm = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            nm.createNotificationChannel(channel)
+        }
+        val intent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_IMMUTABLE)
+        return NotificationCompat.Builder(this, channelId)
+            .setContentTitle(getString(R.string.app_name))
+            .setContentText(getString(R.string.keep_network_active_background))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .build()
+    }
+
+    companion object {
+        const val ACTION_START = "com.bitchat.android.action.START"
+        const val ACTION_USE_BACKGROUND_DELEGATE = "com.bitchat.android.action.BACKGROUND_DELEGATE"
+        private const val CHANNEL_ID = "mesh_foreground"
+        private const val NOTIFICATION_ID = 1
+    }
+}
+

--- a/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
+++ b/app/src/main/java/com/bitchat/android/mesh/BluetoothMeshService.kt
@@ -53,6 +53,7 @@ class BluetoothMeshService(private val context: Context) {
     private val packetProcessor = PacketProcessor(myPeerID)
     
     // Service state management
+    @Volatile
     private var isActive = false
     
     // Delegate for message callbacks (maintains same interface)
@@ -66,6 +67,8 @@ class BluetoothMeshService(private val context: Context) {
         messageHandler.packetProcessor = packetProcessor
         startPeriodicDebugLogging()
     }
+
+    fun isRunning(): Boolean = isActive
     
     /**
      * Start periodic debug logging every 10 seconds

--- a/app/src/main/java/com/bitchat/android/ui/ChatState.kt
+++ b/app/src/main/java/com/bitchat/android/ui/ChatState.kt
@@ -103,12 +103,18 @@ class ChatState {
 
     private val _peerRSSI = MutableLiveData<Map<String, Int>>(emptyMap())
     val peerRSSI: LiveData<Map<String, Int>> = _peerRSSI
-    
+
     // peerIDToPublicKeyFingerprint REMOVED - fingerprints now handled centrally in PeerManager
-    
+
     // Navigation state
     private val _showAppInfo = MutableLiveData<Boolean>(false)
     val showAppInfo: LiveData<Boolean> = _showAppInfo
+
+    // Background settings
+    private val _persistentNetworkEnabled = MutableLiveData(false)
+    val persistentNetworkEnabled: LiveData<Boolean> = _persistentNetworkEnabled
+    private val _startOnBootEnabled = MutableLiveData(false)
+    val startOnBootEnabled: LiveData<Boolean> = _startOnBootEnabled
     
     // Unread state computed properties
     val hasUnreadChannels: MediatorLiveData<Boolean> = MediatorLiveData<Boolean>()
@@ -148,6 +154,8 @@ class ChatState {
     fun getPeerSessionStatesValue() = _peerSessionStates.value ?: emptyMap()
     fun getPeerFingerprintsValue() = _peerFingerprints.value ?: emptyMap()
     fun getShowAppInfoValue() = _showAppInfo.value ?: false
+    fun getPersistentNetworkEnabledValue() = _persistentNetworkEnabled.value ?: false
+    fun getStartOnBootEnabledValue() = _startOnBootEnabled.value ?: false
     
     // Setters for state updates
     fun setMessages(messages: List<BitchatMessage>) {
@@ -255,9 +263,17 @@ class ChatState {
     fun setPeerRSSI(rssi: Map<String, Int>) {
         _peerRSSI.value = rssi
     }
-    
+
     fun setShowAppInfo(show: Boolean) {
         _showAppInfo.value = show
+    }
+
+    fun setPersistentNetworkEnabled(enabled: Boolean) {
+        _persistentNetworkEnabled.value = enabled
+    }
+
+    fun setStartOnBootEnabled(enabled: Boolean) {
+        _startOnBootEnabled.value = enabled
     }
 
 }

--- a/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
+++ b/app/src/main/java/com/bitchat/android/ui/SidebarComponents.kt
@@ -45,6 +45,8 @@ fun SidebarOverlay(
     val unreadChannelMessages by viewModel.unreadChannelMessages.observeAsState(emptyMap())
     val peerNicknames by viewModel.peerNicknames.observeAsState(emptyMap())
     val peerRSSI by viewModel.peerRSSI.observeAsState(emptyMap())
+    val persistentEnabled by viewModel.persistentNetworkEnabled.observeAsState(false)
+    val startOnBootEnabled by viewModel.startOnBootEnabled.observeAsState(false)
 
     Box(
         modifier = modifier
@@ -79,7 +81,7 @@ fun SidebarOverlay(
                 
                 // Scrollable content
                 LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.weight(1f),
                     contentPadding = PaddingValues(vertical = 8.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
@@ -123,6 +125,15 @@ fun SidebarOverlay(
                         )
                     }
                 }
+
+                HorizontalDivider()
+
+                PersistentSettingsSection(
+                    persistentEnabled = persistentEnabled,
+                    startOnBootEnabled = startOnBootEnabled,
+                    onPersistentChanged = { viewModel.setPersistentNetworkEnabled(it) },
+                    onStartOnBootChanged = { viewModel.setStartOnBootEnabled(it) }
+                )
             }
         }
     }
@@ -436,6 +447,39 @@ private fun UnreadBadge(
                     fontWeight = FontWeight.Bold
                 ),
                 color = Color.Black // Black text on yellow background
+            )
+        }
+    }
+}
+
+@Composable
+private fun PersistentSettingsSection(
+    persistentEnabled: Boolean,
+    startOnBootEnabled: Boolean,
+    onPersistentChanged: (Boolean) -> Unit,
+    onStartOnBootChanged: (Boolean) -> Unit
+) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(id = R.string.keep_network_active_background),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Switch(checked = persistentEnabled, onCheckedChange = onPersistentChanged)
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = stringResource(id = R.string.start_network_on_boot),
+                modifier = Modifier.weight(1f),
+                style = MaterialTheme.typography.bodyMedium,
+                color = if (persistentEnabled) MaterialTheme.colorScheme.onSurface else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.4f)
+            )
+            Switch(
+                checked = startOnBootEnabled,
+                onCheckedChange = onStartOnBootChanged,
+                enabled = persistentEnabled
             )
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,8 @@
     <string name="no_one_connected">No one connected</string>
     <string name="emergency_clear_hint">Triple tap to clear all data</string>
     <string name="your_network">Network</string>
+    <string name="keep_network_active_background">Keep network active in background</string>
+    <string name="start_network_on_boot">Start network on boot</string>
     
     <!-- Battery Optimization Strings -->
     <string name="battery_optimization_detected">Battery Optimization Detected</string>


### PR DESCRIPTION
## Summary
- allow users to keep mesh active in background with persistent notification
- add optional start-on-boot setting and boot receiver
- persist private messages received while app is closed
- add foreground service location and background location permissions
- skip onboarding when mesh already running to avoid showing init screen
- automatically start foreground service on launch when persistent networking is enabled and separate background delegate handling
- check location permission before auto-starting foreground service on boot and gracefully exit if missing

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e96036d88333a16ae11425e5befa